### PR TITLE
Fix APK download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A minimalist Android launcher based on Olauncher, customized for VodouLaCroix.
 
 ## 📥 Download Latest APK
-**[Download Latest APK](https://github.com/ether4o4/4GAuteauOS/releases/latest/download/app-debug.apk)**
-*(Automatically built and updated on every push)*
+**[Download Latest APK](https://github.com/ether4o4/4GAuteauOS/releases/latest/download/app-hdpiX86-debug.apk)**
+*(~32 MB · debug-signed · enable "Install unknown apps", then open the APK)*
 
 ## Features
 - Minimalist design


### PR DESCRIPTION
The README's "Download Latest APK" link pointed to `app-debug.apk`, which the build doesn't produce — the actual release asset is `app-hdpiX86-debug.apk`. Updated the link so it resolves, and added size/install note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Db1sFY7yZBWFJVUAxXnfG8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Db1sFY7yZBWFJVUAxXnfG8)_